### PR TITLE
FIX : on ne teste les services exclus que si la conf n'est pas vide

### DIFF
--- a/class/doc2project.class.php
+++ b/class/doc2project.class.php
@@ -10,7 +10,7 @@ class Doc2Project {
 		if (!empty($conf->global->DOC2PROJECT_DO_NOT_CONVERT_SERVICE_WITH_QUANTITY_ZERO) && $line->qty == 0) return true;
 
 		$TExclude = explode(';', $conf->global->DOC2PROJECT_EXCLUDED_PRODUCTS);
-		if (in_array($line->ref, $TExclude)) return true;
+		if (!empty($conf->global->DOC2PROJECT_EXCLUDED_PRODUCTS) && in_array($line->ref, $TExclude)) return true;
 		else return false;
 	}
 	


### PR DESCRIPTION
Sinon pour les lignes libres on se retrouve à chercher si une référence vide existe dans le tableau des services exclus qui justement contient à l'indice 0 une chaîne vide.