### PR TITLE
FIX for nomenclature to task

### DIFF
--- a/class/doc2project.class.php
+++ b/class/doc2project.class.php
@@ -284,7 +284,6 @@ class Doc2Project {
 					if(!empty($nomenclature->TNomenclatureDet)){
 						$detailsNomenclature=$nomenclature->getDetails($line->qty);
 						self::nomenclatureToTask($detailsNomenclature,$line,$object, $project, $start, $end,$stories);
-						
 					}elseif( (!empty($line->fk_product) && $line->fk_product_type == 1)){
 						self::lineToTask($object,$line,$project,$start,$end,0,false,0,$stories);
 					}
@@ -500,6 +499,7 @@ class Doc2Project {
 			$product = new Product($db);
 			$product->fetch($lineNomenclature->fk_product);
 			//On prend les services les plus bas pour créer les taches
+			
 			if (( $product->type == 1) && empty($lineNomenclature->childs))
 			{
 				//Le calcul des quantités est déjà fait grâce à getDetails
@@ -507,6 +507,7 @@ class Doc2Project {
 				$lineNomenclature->desc = $product->description;
 				$nomenclature = new TNomenclature($db);
 				$PDOdb = new TPDOdb($db);
+				
 				$nomenclature->loadByObjectId($PDOdb, $lineNomenclature->rowid,$object->element, false, $lineNomenclature->fk_product);
 				if (!empty($nomenclature->TNomenclatureWorkstation[0]->rowid))
 				{
@@ -517,7 +518,7 @@ class Doc2Project {
 					$idWorkstation = 0;
 				}
 				
-				$lineNomenclature->rowid = $lineNomenclature->rowid.'-'.$line->rowid; //To difference tasks ref
+				$lineNomenclature->rowid = $lineNomenclature->rowid.'-'.$lineNomenclature->fk_product.'-'.$line->rowid; //To difference tasks ref
 				self::lineToTask($object, $lineNomenclature, $project, $start, $end, 0, false, $idWorkstation, $stories);
 				
 			} elseif(!empty($lineNomenclature->childs)){

--- a/class/doc2project.class.php
+++ b/class/doc2project.class.php
@@ -279,7 +279,8 @@ class Doc2Project {
 					dol_include_once('/nomenclature/class/nomenclature.class.php');
 					$nomenclature = new TNomenclature($db);
 					$PDOdb = new TPDOdb($db);
-					$nomenclature->loadByObjectId($PDOdb,$line->fk_product, $object->element, false, $line->fk_product);//get lines of nomenclature
+					
+					$nomenclature->loadByObjectId($PDOdb,$line->rowid, $object->element, false, $line->fk_product);//get lines of nomenclature
 					if(!empty($nomenclature->TNomenclatureDet)){
 						$detailsNomenclature=$nomenclature->getDetails($line->qty);
 						self::nomenclatureToTask($detailsNomenclature,$line,$object, $project, $start, $end,$stories);


### PR DESCRIPTION
- Replace $line->fk_product by $line->rowid in loadbyobjectid function

- Add fk product in ref because when there is  nomenclature line with no id, but multiple services on nomenclature, we only have one line in scrumboard because they have same ref.