### PR TITLE
FIX : create tasks from nomenclature

### DIFF
--- a/class/doc2project.class.php
+++ b/class/doc2project.class.php
@@ -284,7 +284,7 @@ class Doc2Project {
 			elseif (!empty($conf->global->DOC2PROJECT_USE_NOMENCLATURE_AND_WORKSTATION))
 			{
 				//self::createOneTask(...); //Avec les postes de travails liés à la nomenclature
-				if(!empty($line->fk_product)) {
+				if(! empty($line->fk_product) || (! empty($conf->global->DOC2PROJECT_ALLOW_FREE_LINE) && ! empty($conf->global->NOMENCLATURE_ALLOW_FREELINE))) {
 					define('INC_FROM_DOLIBARR',true);
 					dol_include_once('/nomenclature/config.php');
 					dol_include_once('/nomenclature/class/nomenclature.class.php');

--- a/class/doc2project.class.php
+++ b/class/doc2project.class.php
@@ -292,9 +292,8 @@ class Doc2Project {
 					$PDOdb = new TPDOdb($db);
 					
 					$nomenclature->loadByObjectId($PDOdb,$line->rowid, $object->element, false, $line->fk_product);//get lines of nomenclature
-					$nomenclature->setPrice($PDOdb, $line->qty, null, $object->element, $line->rowid, $line->fk_product);
 					if(!empty($nomenclature->TNomenclatureDet)){
-						self::nomenclatureToTask($nomenclature, $line, $object, $project, $start, $end, $story);
+						self::nomenclatureToTask($PDOdb, $nomenclature, $line, $object, $project, $start, $end, $story);
 					}elseif( (!empty($line->fk_product) && $line->fk_product_type == 1)){
 						self::lineToTask($object,$line,$project,$start,$end,0,false,0, $story);
 					}
@@ -540,10 +539,11 @@ class Doc2Project {
 	 * $object => objet courant (propal/order)
 	 * 
 	 */
-	public static function nomenclatureToTask(TNomenclature $nomenclature, $line, $object, $project, $start, $end, $stories='')
+	public static function nomenclatureToTask(TPDOdb &$PDOdb, TNomenclature &$nomenclature, $line, $object, $project, $start, $end, $stories='')
 	{
 		global $db;
 
+		$nomenclature->setPrice($PDOdb, $line->qty, null, $object->element, $line->rowid, $line->fk_product);
         $detailsNomenclature = $nomenclature->getDetails($line->qty);
 
         $i = 0;
@@ -583,9 +583,11 @@ class Doc2Project {
                 {
                     $coef = $line->qty / $nomenclature->qty_reference;
                 }
+
                 $qty = $lineNomen->qty * $coef;
+
 			    $childNomenclature = TNomenclatureDet::getArboNomenclatureDet($PDOdb, $lineNomen, $qty);
-				self::nomenclatureToTask($childNomenclature, $line, $object, $project, $start, $end, $stories);
+				self::nomenclatureToTask($PDOdb, $childNomenclature, $line, $object, $project, $start, $end, $stories);
 			}
 
             $i++;


### PR DESCRIPTION
Avec la conversion depuis les nomenclatures :
- Les lignes libres sont toujours ignorées, même si les confs de Doc2Project et de Nomenclature sont activées
- Le prix de vente n'est pas rempli
- Le code était difficilement compréhensible (bon, c'est subjectif...)