### PR TITLE
T1831 lacevenements date filter for statistics report

### DIFF
--- a/admin/doc2project_setup.php
+++ b/admin/doc2project_setup.php
@@ -59,7 +59,7 @@ if (preg_match('/set_(.*)/',$action,$reg))
 		dol_print_error($db);
 	}
 }
-	
+
 if (preg_match('/del_(.*)/',$action,$reg))
 {
 	$code=$reg[1];
@@ -106,7 +106,7 @@ if($ok) {
 	print '<td>'.$langs->trans("Parameters").'</td>'."\n";
 	print '<td align="center" width="20">&nbsp;</td>';
 	print '<td align="center" width="100">'.$langs->trans("Value").'</td>'."\n";
-	
+
 	// Display convert button on proposal
 	if($conf->propal->enabled) {
 		$var=!$var;
@@ -122,7 +122,7 @@ if($ok) {
 		print '</form>';
 		print '</td></tr>';
 	}
-	
+
 	// Display convert button on order
 	if($conf->commande->enabled) {
 		$var=!$var;
@@ -152,7 +152,7 @@ if($ok) {
 	print '<input type="submit" class="button" value="'.$langs->trans("Modify").'">';
 	print '</form>';
 	print '</td></tr>';
-	
+
 	// Nb hour a day
 	$var=!$var;
 	print '<tr '.$bc[$var].'>';
@@ -166,8 +166,8 @@ if($ok) {
 	print '<input type="submit" class="button" value="'.$langs->trans("Modify").'">';
 	print '</form>';
 	print '</td></tr>';
-	
-	
+
+
 	$var=!$var;
 	print '<tr '.$bc[$var].'>';
 	print '<td>'.$langs->trans("Doc2ProjectValidateProjectOnValidateOrder").'</td>';
@@ -180,7 +180,7 @@ if($ok) {
 	print '<input type="submit" class="button" value="'.$langs->trans("Modify").'">';
 	print '</form>';
 	print '</td></tr>';
-	
+
 	$var=!$var;
 	print '<tr '.$bc[$var].'>';
 	print '<td>'.$langs->trans("Doc2ProjectClotureProjectOnValidateExpedition").'</td>';
@@ -193,8 +193,21 @@ if($ok) {
 	print '<input type="submit" class="button" value="'.$langs->trans("Modify").'">';
 	print '</form>';
 	print '</td></tr>';
-	
-	
+
+	$var=!$var;
+	print '<tr '.$bc[$var].'>';
+	print '<td>'.$langs->trans("DOC2PROJECT_SHOW_DOCUMENT_DATE_FILTER_ON_STATISTICS_REPORT").'</td>';
+	print '<td align="center" width="20">&nbsp;</td>';
+	print '<td align="right" width="300">';
+	print '<form method="POST" action="'.$_SERVER['PHP_SELF'].'">';
+	print '<input type="hidden" name="token" value="'.$_SESSION['newtoken'].'">';
+	print '<input type="hidden" name="action" value="set_DOC2PROJECT_SHOW_DOCUMENT_DATE_FILTER_ON_STATISTICS_REPORT">';
+	print $form->selectyesno('DOC2PROJECT_SHOW_DOCUMENT_DATE_FILTER_ON_STATISTICS_REPORT', $conf->global->DOC2PROJECT_SHOW_DOCUMENT_DATE_FILTER_ON_STATISTICS_REPORT, 1);
+	print '<input type="submit" class="button" value="'.$langs->trans("Modify").'">';
+	print '</form>';
+	print '</td></tr>';
+
+
 } else {
 	print $langs->trans('ModuleNeedProposalOrOrderModule');
 }

--- a/filtres.php
+++ b/filtres.php
@@ -31,15 +31,23 @@ function _print_filtre_societe(&$form,&$PDOdb){
 		</tr>
 	<?php
 }
-function _print_filtre_plage_date(&$form){
+
+	/**
+	 * @param TFormCore $form
+	 * @param string $prefix
+	 */
+function _print_filtre_plage_date(&$form, $prefix){
+	global $langs, $db;
+	$stdform = new Form($db);
+	$helpPrefix = ucfirst($prefix);
 	?>
 		<tr>
-			<td>Date de début : </td>
-			<td><?php echo $form->calendrier('', 'date_deb', ($_REQUEST['date_deb'])? $_REQUEST['date_deb'] : ''); ?></td>
+			<td><?php echo $stdform->textwithpicto($langs->trans($helpPrefix . 'StartDate'), $langs->trans($helpPrefix . 'StartDateHelp')) ?></td>
+			<td><?php echo $form->calendrier('', $prefix . '_start_date', ($_REQUEST[$prefix . '_start_date'])? $_REQUEST[$prefix . '_start_date'] : ''); ?></td>
 		</tr>
 		<tr>
-			<td>Date de fin : </td>
-			<td><?php echo $form->calendrier('', 'date_fin', ($_REQUEST['date_fin'])? $_REQUEST['date_fin'] : ''); ?></td>
+			<td><?php echo $stdform->textwithpicto($langs->trans($helpPrefix . 'EndDate'), $langs->trans($helpPrefix . 'EndDateHelp')) ?></td>
+			<td><?php echo $form->calendrier('', $prefix . '_end_date', ($_REQUEST[$prefix . '_end_date'])? $_REQUEST[$prefix . '_end_date'] : ''); ?></td>
 		</tr>
 	<?php
 }

--- a/langs/fr_FR/doc2project.lang
+++ b/langs/fr_FR/doc2project.lang
@@ -18,6 +18,7 @@ NbHoursPerDay = Nombre d'heure journalier
 ModuleNeedProposalOrOrderModule = Le module proposition commerciale ou commande client doit être activé pour pouvoir utiliser ce module
 Doc2ProjectValidateProjectOnValidateOrder=Créer et valider un projet sur la validation d'une commande client
 Doc2ProjectClotureProjectOnValidateExpedition=Clôturer le projet sur la validation d'une expédition
+DOC2PROJECT_SHOW_DOCUMENT_DATE_FILTER_ON_STATISTICS_REPORT=Dans le rapport statistique, permettre de filtrer par date les documents pris en compte dans les statistiques
 
 Doc2ProjectTitle=%s
 Doc2ProjectProjectCreated=Projet %s créé
@@ -28,6 +29,7 @@ Doc2ProjectErrorProjectNotFound=Aucun projet lié
 Doc2ProjectErrorProjectCantBeClose=Impossible de clôturer le projet %s
 Doc2ProjectProjectAlreadyClose=Projet (%s) déjà clot
 Doc2ProjectProjectAsBeenClose=Le projet (%s) a était clôturé
+Doc2ProjectErrorDateStartBeforeEnd=Erreur : filtrage impossible : la date de début est ultérieure à la date de fin
 
 SoldPrice=Prix vendu
 CostEffective=Coût effectif (temps consommé)
@@ -35,3 +37,13 @@ SoldPrice=Montant vendu
 TotalBill=Montant total des factures
 OtherExpenses=Autres dépenses (Achat, NdF, ...)
 TotalPropal=Montant total des propositions signées
+
+ProjectStartDate=Date de début (projets)
+ProjectEndDate=Date de fin (projets)
+ProjectStartDateHelp=Seuls les projets dont l’événement se termine à cette date ou ultérieurement seront affichés.
+ProjectEndDateHelp=Seuls les projets dont l’événement démarre à cette date ou antérieurement seront affichés.
+
+DocumentStartDate=Date de début (documents)
+DocumentEndDate=Date de fin (documents)
+DocumentStartDateHelp=Pour les projets affichés, seuls les documents dont la date est comprise dans la plage sélectionnée seront pris en compte dans les statistiques
+DocumentEndDateHelp=Pour les projets affichés, seuls les documents dont la date est comprise dans la plage sélectionnée seront pris en compte dans les statistiques

--- a/rapport.php
+++ b/rapport.php
@@ -13,7 +13,7 @@ print_fiche_titre($langs->trans("Report"));
 <link rel="stylesheet" href="<?php echo COREHTTP?>includes/js/dataTable/css/jquery.dataTables.css" type="text/css" />
 <link rel="stylesheet" href="<?php echo COREHTTP?>includes/js/dataTable/css/dataTables.tableTools.css" type="text/css" />
 <?php
-
+$langs->load('doc2project@doc2project');
 $PDOdb=new TPDOdb;
 
 // Get parameters
@@ -21,9 +21,10 @@ _action($PDOdb);
 
 llxFooter();
 
+/**
+ * @param TPDOdb $PDOdb
+ */
 function _action(&$PDOdb) {
-	global $user, $conf;
-
 	if(isset($_REQUEST['action'])) {
 		switch($_REQUEST['action']) {
 
@@ -104,7 +105,7 @@ function _fiche(&$PDOdb,$report=''){
 			echo $form->btsubmit('Afficher', '');
 		}
 
-		echo $form->end();
+		$form->end();
 
 		switch ($report) {
 			case 'statistiques_projet':
@@ -119,7 +120,13 @@ function _fiche(&$PDOdb,$report=''){
 	echo '</div>';
 }
 
+/**
+ * @param string $report
+ * @param TPDOdb $PDOdb
+ * @param TFormCore $form
+ */
 function _get_filtre($report,$PDOdb,$form){
+	global $conf;
 
 	print_fiche_titre('Filtres');
 	echo '<div class="tabBar">';
@@ -128,7 +135,10 @@ function _get_filtre($report,$PDOdb,$form){
 	switch ($report) {
 		case 'statistiques_projet':
 			_print_filtre_liste_projet($form,$PDOdb);
-			_print_filtre_plage_date($form);
+			_print_filtre_plage_date($form, 'project');
+			if (!empty($conf->global->DOC2PROJECT_SHOW_DOCUMENT_DATE_FILTER_ON_STATISTICS_REPORT)) {
+				_print_filtre_plage_date($form, 'document');
+			}
 			_print_filtre_type_projet($form, $PDOdb);
 			break;
 
@@ -142,52 +152,86 @@ function _get_filtre($report,$PDOdb,$form){
 	echo '</div>';
 }
 
+	/**
+	 * @param string $prefix
+	 * @return object
+	 */
+function _get_date_filter($prefix) {
+	$start = GETPOST($prefix . '_start_date', 'alpha');
+	$end   = GETPOST($prefix . '_end_date',   'alpha');
+	if (!empty($start)) $t_start = Tools::get_time($start); else $t_start = 0;
+	if (!empty($end))   $t_end   = Tools::get_time($end);   else $t_end   = 0;
+	return (object) array(
+		'start_str' => $start,
+		'end_str'   => $end,
+		'start' => $t_start,
+		'end'   => $t_end,
+		'wrong_order' => ($t_start && $t_end && $t_start > $t_end),
+	);
+}
+
+/**
+ * @param TPDOdb $PDOdb
+ */
 function _get_statistiques_projet(&$PDOdb){
-	global $db,$conf;
+	global $conf, $langs;
 
 	$idprojet = GETPOST('id_projet');
 
-	$date_deb = GETPOST('date_deb');
-	$t_deb = !$date_deb ? 0 : Tools::get_time($date_deb);
+	$projectDateFilter = _get_date_filter('project');
+	$documentDateFilter = _get_date_filter('document');
 
-	$date_fin = GETPOST('date_fin');
-	$t_fin = !$date_fin ? 0 : Tools::get_time($date_fin);
-
-	$sql = "SELECT p.rowid as IdProject, p.ref, p.title, pe.datevent, pe.datefin, pe.typeevent
-	, (
-		SELECT SUM(f.total) FROM ".MAIN_DB_PREFIX."facture as f WHERE f.fk_projet = p.rowid AND f.fk_statut IN(1, 2)
-		".($t_deb>0 && $t_fin>0 ? " AND datef BETWEEN '".date('Y-m-d', $t_deb)."' AND '".date('Y-m-d', $t_fin)."' " : ''  )."
-		) as total_vente
-	,
-	(SELECT SUM(total_ht) FROM " . MAIN_DB_PREFIX . "propal as prop WHERE prop.fk_statut = 2  AND prop.fk_projet = p.rowid) as total_vente_futur
-	,(SELECT SUM(total_ht) FROM " . MAIN_DB_PREFIX . "propal as prop WHERE prop.fk_statut <> 0 AND prop.fk_projet = p.rowid) as total_vente_previsionnel
-	, (
-		SELECT SUM(ff.total_ht) FROM ".MAIN_DB_PREFIX."facture_fourn as ff WHERE ff.fk_projet = p.rowid AND ff.fk_statut >= 1
-		".($t_deb>0 && $t_fin>0 ? " AND datef BETWEEN '".date('Y-m-d', $t_deb)."' AND '".date('Y-m-d', $t_fin)."' " : ''  )."
-	) as total_achat
-	,(SELECT SUM(total_ht) FROM " . MAIN_DB_PREFIX . "commande_fournisseur as cmd WHERE cmd.fk_statut <> 0 AND cmd.fk_projet = p.rowid) as total_achat_futur
-	";
-
-	if($conf->ndfp->enabled){
-		$sql .=" , (
-			SELECT SUM(ndfp.total_ht) FROM ".MAIN_DB_PREFIX."ndfp as ndfp WHERE ndfp.fk_project = p.rowid AND ndfp.statut >= 1
-			".($t_deb>0 && $t_fin>0 ? " AND datef BETWEEN '".date('Y-m-d', $t_deb)."' AND '".date('Y-m-d', $t_fin)."' " : ''  )."
-		) as total_ndf ";
+	// make sure that $date_deb and $date_fin are in the right order
+	if ($projectDateFilter->wrong_order) {
+		$langs->load('doc2project@doc2project');
+		setEventMessages($langs->trans('Doc2ProjectErrorDateStartBeforeEnd'), array(), 'errors');
+		return;
 	}
 
-	$sql .= ", (SELECT SUM(tt.task_duration) FROM ".MAIN_DB_PREFIX."projet_task_time as tt WHERE tt.fk_task IN (
-			SELECT t.rowid FROM ".MAIN_DB_PREFIX."projet_task as t WHERE t.fk_projet = p.rowid)
-		".($t_deb>0 && $t_fin>0 ? " AND task_date BETWEEN '".date('Y-m-d', $t_deb)."' AND '".date('Y-m-d', $t_fin)."' " : ''  )."
-	) as total_temps
-	,(SELECT SUM(tt.thm * tt.task_duration/3600) FROM ".MAIN_DB_PREFIX."projet_task_time as tt WHERE tt.fk_task IN (
-			SELECT t.rowid FROM ".MAIN_DB_PREFIX."projet_task as t WHERE t.fk_projet = p.rowid)
-		".($t_deb>0 && $t_fin>0 ? " AND task_date BETWEEN '".date('Y-m-d', $t_deb)."' AND '".date('Y-m-d', $t_fin)."' " : ''  )."
-	) as total_cout_homme
+	// subqueries
+	$sqlTotalVente       = 'SELECT SUM(f.total) FROM                        ' . MAIN_DB_PREFIX . 'facture as f               '. ' WHERE f.fk_projet = p.rowid AND f.fk_statut IN (1, 2)';
+	$sqlTotalVenteFutur  = 'SELECT SUM(total_ht) FROM                       ' . MAIN_DB_PREFIX . 'propal as prop             '. ' WHERE prop.fk_statut = 2  AND prop.fk_projet = p.rowid';
+	$sqlTotalVentePrevis = 'SELECT SUM(total_ht) FROM                       ' . MAIN_DB_PREFIX . 'propal as prop             '. ' WHERE prop.fk_statut <> 0 AND prop.fk_projet = p.rowid';
+	$sqlTotalAchat       = 'SELECT SUM(ff.total_ht) FROM                    ' . MAIN_DB_PREFIX . 'facture_fourn as ff        '. ' WHERE ff.fk_projet = p.rowid AND ff.fk_statut >= 1';
+	$sqlTotalAchatFutur  = 'SELECT SUM(total_ht) FROM                       ' . MAIN_DB_PREFIX . 'commande_fournisseur as cmd'. ' WHERE cmd.fk_statut <> 0 AND cmd.fk_projet = p.rowid';
+	$sqlTotalNDF         = 'SELECT SUM(ndfp.total_ht) FROM                  ' . MAIN_DB_PREFIX . 'ndfp as ndfp               '. ' WHERE ndfp.fk_project = p.rowid AND ndfp.statut >= 1';
+	$sqlTotalTemps       = 'SELECT SUM(tt.task_duration) FROM               ' . MAIN_DB_PREFIX . 'projet_task_time as tt     '. ' WHERE tt.fk_task IN (SELECT t.rowid FROM ' . MAIN_DB_PREFIX . 'projet_task as t WHERE t.fk_projet = p.rowid)';
+	$sqlTotalCoutHomme   = 'SELECT SUM(tt.thm * tt.task_duration/3600) FROM ' . MAIN_DB_PREFIX . 'projet_task_time as tt     '. ' WHERE tt.fk_task IN (SELECT t.rowid FROM ' . MAIN_DB_PREFIX . 'projet_task as t WHERE t.fk_projet = p.rowid)';
 
-			FROM ".MAIN_DB_PREFIX."projet as p
-			INNER JOIN " . MAIN_DB_PREFIX . "projet_extrafields as pe ON pe.fk_object = p.rowid
-			WHERE 1 = 1
-	 ";
+	// some subqueries can have an additional date restriction
+	if (!empty($conf->global->DOC2PROJECT_SHOW_DOCUMENT_DATE_FILTER_ON_STATISTICS_REPORT)) {
+		$addDateRestriction = function($fieldName) use ($documentDateFilter, $PDOdb) {
+			if ($documentDateFilter->start == 0 || $documentDateFilter->end == 0) return '';
+			return sprintf(
+				' AND %s BETWEEN %s AND %s ',
+				$fieldName,
+				$PDOdb->quote(date('Y-m-d', $documentDateFilter->start)),
+				$PDOdb->quote(date('Y-m-d', $documentDateFilter->end))
+			);
+		};
+		$sqlTotalVente     .= $addDateRestriction('datef');
+		$sqlTotalAchat     .= $addDateRestriction('datef');
+		$sqlTotalNDF       .= $addDateRestriction('datef');
+		$sqlTotalTemps     .= $addDateRestriction('task_date');
+		$sqlTotalCoutHomme .= $addDateRestriction('task_date');
+	}
+
+	$sql = 'SELECT p.rowid AS IdProject, p.ref, p.title, pe.datevent, pe.datefin, pe.typeevent, '
+		. "\n" . ' (' . $sqlTotalVente       . ') AS total_vente,'
+		. "\n" . ' (' . $sqlTotalVenteFutur  . ') AS total_vente_futur,'
+		. "\n" . ' (' . $sqlTotalVentePrevis . ') AS total_vente_previsionnel,'
+		. "\n" . ' (' . $sqlTotalAchat       . ') AS total_achat,'
+		. "\n" . ' (' . $sqlTotalAchatFutur  . ') AS total_achat_futur,'
+		. (($conf->ndfp->enabled) ? "\n" . ' (' . $sqlTotalNDF . ') AS total_ndf,' : '')
+		. "\n" . ' (' . $sqlTotalTemps       . ') AS total_temps,'
+		. "\n" . ' (' . $sqlTotalCoutHomme   . ') AS total_cout_homme'
+		. "\n" . ' FROM ' . MAIN_DB_PREFIX . 'projet AS p'
+		. "\n" . ' INNER JOIN ' . MAIN_DB_PREFIX . 'projet_extrafields AS pe ON pe.fk_object = p.rowid'
+		. ' WHERE 1 = 1';
+	$sqlProjectEndsAfterFilterStartDate  = ' AND pe.datefin  >= ' . $PDOdb->quote(date('Y-m-d', $projectDateFilter->start));
+	$sqlProjectStartsBeforeFilterEndDate = ' AND pe.datevent <= ' . $PDOdb->quote(date('Y-m-d', $projectDateFilter->end));
+	if (!empty($projectDateFilter->start_str)) $sql .= $sqlProjectEndsAfterFilterStartDate;
+	if (!empty($projectDateFilter->end_str))   $sql .= $sqlProjectStartsBeforeFilterEndDate;
 
 	if($idprojet > 0) $sql.= " AND p.rowid = ".$idprojet;
 
@@ -206,11 +250,11 @@ function _get_statistiques_projet(&$PDOdb){
 	} else {
 		$sql .= 'pe.datevent';
 	}
+	print '<pre>' . $sql . '</pre>' ;exit;
 
 	$PDOdb->Execute($sql);
 
 	$TRapport = array();
-	$PDOdb2 = new TPDOdb;
 
 	while ($PDOdb->Get_line()) {
 		//echo ($conf->global->DOC2PROJECT_NB_HOURS_PER_DAY*60*60).'<br>';
@@ -257,17 +301,14 @@ function _get_statistiques_projet(&$PDOdb){
 		$TRapport['total_ndf'] = $PDOdb->Get_field('total_ndf');
 	}
 
-	_print_statistiques_projet($TRapport);
+	_print_statistiques_projet($TRapport, $sortfield, $sortorder);
 }
 
-function _print_statistiques_projet(&$TRapport){
+function _print_statistiques_projet(&$TRapport, $sortfield, $sortorder){
 	global $conf, $db;
 
 	dol_include_once('/core/lib/date.lib.php');
 	dol_include_once('/projet/class/project.class.php');
-
-	$selected_type = GETPOST('type_event');
-	$id_projet = GETPOST('');
 
 	$params = $_SERVER['QUERY_STRING'];
 
@@ -302,7 +343,17 @@ function _print_statistiques_projet(&$TRapport){
 			</thead>
 			<tbody>
 				<?php
-
+				$total_vente = 0;
+				$total_achat = 0;
+				$total_ndf = 0;
+				$total_temps = 0;
+				$total_cout_homme = 0;
+				$total_marge = 0;
+				$total_marge_futur = 0;
+				$total_marge_prev = 0;
+				$total_vente_futur = 0;
+				$total_vente_previsionnel = 0;
+				$total_achat_futur = 0;
 				foreach($TRapport as $line){
 					$project=new Project($db);
 					$project->fetch($line['IdProject']);


### PR DESCRIPTION
Dans le rapport statistiques, il y a un filtre par dates. Sur la master, même si on applique ce filtre, tous les projets sont listés dans le rapport car ce filtre limite uniquement les documents (factures, tâches) pris en compte dans l’agrégation de stats par projet, ce qui n’est pas très intuitif (mais ça a dû être fait pour une raison, même si on n’a pas retrouvé laquelle). La branche lacevenements fait pareil, à part que les dates (pour l’affichage et le filtrage) sont pris sur des extrafields et pas directement sur le projet.

J’ai changé ce comportement en créant 2 filtres par dates distincts : le premier fait un filtrage "intuitif" : il permet de n’afficher que les projets dont la plage de date possède une intersection avec la plage de date choisie.

L’autre, optionnel (caché par défaut mais affichable par une conf), reprend le comportement d’origine.

Les deux filtres peuvent être utilisés ensemble et des tooltips expliquent ce qu’ils font.

Comme (au moins pour ce rapport) la différence principale entre la branche lacevenements et la master réside dans le champ date utilisée, il faudrait envisager de remonter une partie de ce dev dans la master.