### PR TITLE
FIX: when the duration unit is 'h', the task duration is calculated as if it were 'd'

### DIFF
--- a/class/doc2project.class.php
+++ b/class/doc2project.class.php
@@ -224,6 +224,7 @@ class Doc2Project {
 				$durationInSec = $line->qty * (empty($product->duration_value) ? 0 : $product->duration_value) * 3600 * $conf->global->DOC2PROJECT_NB_HOURS_PER_DAY;
 				$nbDays = $line->qty * (empty($product->duration_value)?0:$product->duration_value);
 			} else if($product->duration_unit == 'h') { // Service vendu à l'heure, la date de fin dépend du nombre d'heure vendues
+				$durationInSec = $line->qty * (empty($product->duration_value) ? 0 : $product->duration_value) * 3600;
 				$nbDays = ceil($line->qty * (empty($product->duration_value) ? 0 : $product->duration_value) / $conf->global->DOC2PROJECT_NB_HOURS_PER_DAY);
 			} else if($product->duration_unit == 'i') { // Service vendu à la minute
                 $durationInSec = $line->qty * (empty($product->duration_value) ? 0 : $product->duration_value) * 60;


### PR DESCRIPTION
## Context
Say you have a proposal with a compound (nomenclature) product. Your product's nomenclature contains a service with a duration of 1h.

You create a project and tasks from this proposal using doc2project.

You expect the task duration to be 1h, but you find it is 9h (or whatever value is set for DOC2PROJECT_NB_HOURS_PER_DAY).

## Why?
Before commit dce28ded2d1c10cae545edf504f5944740abfe4c, it wasn't possible to use minutes as the billing unit.

When the option was added, the duration in seconds was no longer computed for hours (only for days and minutes), resulting in a default calculation being used (which assumed the unit was days).