### PR TITLE
T2691 - nouveau hook pour intervenir après la création de toutes les tâches

### DIFF
--- a/class/doc2project.class.php
+++ b/class/doc2project.class.php
@@ -1,7 +1,7 @@
 <?php
 
 class Doc2Project {
-	
+
 	public static function isExclude(&$line)
 	{
 		global $conf;
@@ -13,14 +13,14 @@ class Doc2Project {
 		if (!empty($conf->global->DOC2PROJECT_EXCLUDED_PRODUCTS) && in_array($line->ref, $TExclude)) return true;
 		else return false;
 	}
-	
+
 	public static function get_project_ref(&$project) {
 		global $conf;
 		$project->fetch_thirdparty();
-	
+
 		$defaultref='';
 		$modele = empty($conf->global->PROJECT_ADDON)?'mod_project_simple':$conf->global->PROJECT_ADDON;
-	
+
 		// Search template files
 		$file=''; $classname=''; $filefound=0;
 		$dirmodels=array_merge(array('/'),(array) $conf->modules_parts['models']);
@@ -34,39 +34,39 @@ class Doc2Project {
 				break;
 			}
 		}
-	
+
 		if ($filefound)
 		{
 			$result=dol_include_once($reldir."core/modules/project/".$modele.'.php');
 			$modProject = new $classname;
-	
+
 			$defaultref = $modProject->getNextValue($project->thirdparty,$project);
 		}
-	
+
 		return $defaultref;
 	}
-	
+
 	public static function createProject(&$object) {
-		
+
 		global $conf,$langs,$db,$user,$hookmanager;
-		
+
 		if (!class_exists('Project')) dol_include_once('/projet/class/project.class.php');
 		if (!class_exists('Task')) dol_include_once('/projet/class/task.class.php');
-		
+
 		if(empty($object->thirdparty)) $object->fetch_thirdparty();
-		
+
 		$project = new Project($db);
-		
+
 		if(!empty($conf->global->DOC2PROJECT_SEARCH_CUSTOMER_PROJECT) && $object->thirdparty->has_projects()) {
 			$fk_projet = self::getCustomerProjectEprolor($object);
 			if($fk_projet) {
-				
+
 				$project->fetch($fk_projet);
-				
+
 				$object->setProject($project->id);
-	
+
 				if($project->id>0) return $project;
-				
+
 			}
 		}
 
@@ -75,14 +75,14 @@ class Doc2Project {
 		$langs->load('doc2project@doc2project');
 		if (!class_exists('Project')) dol_include_once('/projet/class/project.class.php');
 		if (!class_exists('Task')) dol_include_once('/projet/class/task.class.php');
-		
+
 		if(empty($object->thirdparty)) $object->fetch_thirdparty();
-		
+
 		$project = new Project($db);
-		
+
 		$action = 'createProject';
 		$reshook = $hookmanager->executeHooks('createProject', array('project' => &$project), $object, $action);
-		
+
 		if (!empty($hookmanager->resArray))
 		{
 			$project=&$hookmanager->resArray[0];
@@ -93,9 +93,9 @@ class Doc2Project {
 			if (!empty($object->fk_project))
 			{
 				$r = $project->fetch($object->fk_project);
-				
+
 				if (!empty($conf->global->DOC2PROJECT_SET_PROJECT_DRAFT)) { $res = $project->setStatut(0); $project->statut = 0; }
-				
+
 				if($project->id>0) return $project;
 				else return false;
 			}
@@ -103,7 +103,7 @@ class Doc2Project {
 			$langs->load('doc2project@doc2project');
 
 			$project = new Project($db);
-			
+
 			// ref is still PROV if coming from VALIDATE trigger
 			if(preg_match('/^[\(]?PROV/i', $object->ref)) {
 				$object->ref = $object->newref;
@@ -118,7 +118,7 @@ class Doc2Project {
 
 				if(!empty($object->array_options )) {
 					foreach($object->array_options as $k=>$v) {
-						$Trans['{'.$k.'}'] = $v;	
+						$Trans['{'.$k.'}'] = $v;
 					}
 				}
 
@@ -154,8 +154,8 @@ class Doc2Project {
 				setEventMessage($langs->transnoentitiesnoconv('Doc2ProjectErrorCreateProject', $r), 'errors');
 			}
 		}
-		
-		
+
+
 		return false;
 	}
 
@@ -163,19 +163,19 @@ class Doc2Project {
 	 * Renvoie le projet dont la commande a la même RAL que celle de la commande qu'on est en train de valider
 	 */
 	public static function getCustomerProjectEprolor(&$object) {
-		
+
 		global $db;
-		
+
 		if(empty($object->lines))$object->fetch_lines();
-		
+
 		$ral_commande_actuelle = self::getRALLabel($object);
-		
+
 		// Récupération des projets du client
 		$sql = 'SELECT rowid
 				FROM '.MAIN_DB_PREFIX.'projet
 				WHERE fk_soc = '.$object->thirdparty->id;
 		$resql = $db->query($sql);
-		
+
 		while($res = $db->fetch_object($resql)) {
 			// Récupération de la ou des commandes liées au projet
 			$sql = 'SELECT rowid FROM '.MAIN_DB_PREFIX.'commande WHERE fk_projet = '.$res->rowid;
@@ -184,7 +184,7 @@ class Doc2Project {
 				$commande = new Commande($db);
 				$commande->fetch($res2->rowid);
 				$commande->fetch_lines();
-				// Parcours des lignes de la commande pour vérifier 
+				// Parcours des lignes de la commande pour vérifier
 				// si l'une d'elles contient la même RAL que la commande qu'on est en train de valider
 				foreach($commande->lines as $line) {
 					if($line->ref === $ral_commande_actuelle) return $res->rowid; // id project
@@ -193,43 +193,43 @@ class Doc2Project {
 		}
 
 		return 0;
-		
+
 	}
 
 	public static function getRALLabel(&$object) {
-		
+
 		foreach($object->lines as $line) {
 			if(strpos($line->ref, 'RAL_') !== false) return $line->ref;
 		}
-		
+
 	}
-	
+
 	public static function lineToTask(&$object,&$line, &$project,&$start,&$end,$fk_parent=0,$isParent=false,$fk_workstation=0,$story='') {
-		
+
 		global $conf,$langs,$db,$user;
-		
+
 		$product = new Product($db);
 		if (!empty($line->fk_product)) $product->fetch($line->fk_product);
-		
+
 		if(empty($fk_workstation) && !empty($line->array_options['options_fk_workstation'])) {
 			$fk_workstation = $line->array_options['options_fk_workstation'];
 		}
-		
+
 		if(empty($fk_workstation) && !empty($object->array_options['options_fk_workstation'])) {
 			$fk_workstation = $object->array_options['options_fk_workstation'];
 		}
-		
-		
+
+
 		$durationInSec = $end = '';
 		if(!empty($conf->global->DOC2PROJECT_CONVERSION_RULE)) {
-		
+
 			$Trans = array(
 					'{qty}'=>$line->qty
 					,'{totalht}'=>$line->total_ht
 					,'{fk_workstation}'=>$fk_workstation
-					
+
 			);
-			
+
 			if(!empty($conf->workstation->enabled) && $fk_workstation>0) {
 				define('INC_FROM_DOLIBARR',true);
 				dol_include_once('/workstation/config.php');
@@ -239,22 +239,22 @@ class Doc2Project {
 				$ws->load($PDOdb, $fk_workstation);
 				$Trans['{workstation_code}']=$ws->code;
 			}
-			
+
 			$eval = strtr($conf->global->DOC2PROJECT_CONVERSION_RULE,$Trans);
-			
+
 			if(strpos($eval,'return ')===false)$eval = 'return ('.$eval.');';
-			
+
 			$durationInSec = eval($eval) * 3600;
 			$nbDays = ceil(($durationInSec / 3600) / $conf->global->DOC2PROJECT_NB_HOURS_PER_DAY);
-		
+
 		}
 		else if($line->ref!=null){
 			$product->fetch($line->fk_product);
-		
+
 			// On part du principe que les services sont vendus à l'heure ou au jour. Pas au mois ni autre.
-		
+
 			$durationInSec = $line->qty * $product->duration_value * 3600;
-		
+
 			$nbDays = 0;
 			if($product->duration_unit == 'd') { // Service vendu au jour, la date de fin dépend du nombre de jours vendus
 				$durationInSec *= $conf->global->DOC2PROJECT_NB_HOURS_PER_DAY;
@@ -263,57 +263,58 @@ class Doc2Project {
 				$nbDays = ceil($line->qty * $product->duration_value / $conf->global->DOC2PROJECT_NB_HOURS_PER_DAY);
 			}
 		} else {
-		
+
 			$durationInSec = $line->qty *$conf->global->DOC2PROJECT_NB_HOURS_PER_DAY* 3600;
 			$nbDays = $line->qty;
-		
+
 		}
-		
+
 		$end = strtotime('+'.$nbDays.' weekdays', $start);
-		
+
 		$t = new Task($db);
 		$defaultref='';
 		if(!empty($conf->global->DOC2PROJECT_TASK_REF_PREFIX)) {
 			$defaultref = $conf->global->DOC2PROJECT_TASK_REF_PREFIX.$line->rowid;
 		}
-		
+
 		if (!empty($conf->global->DOC2PROJECT_TASK_NAME)) $label = strtr($conf->global->DOC2PROJECT_TASK_NAME, array('{product_ref}' => $line->ref, '{product_label}' => $line->product_label));
 		else $label = !empty($line->product_label) ? $line->product_label : $line->desc;
-		
-//var_dump($defaultref, $label,  $project->id);exit;		
+
+//var_dump($defaultref, $label,  $project->id);exit;
 		return self::createOneTask( $project->id, $defaultref, $label, $line->desc, $start, $end, $fk_parent, $durationInSec, $line->total_ht,$fk_workstation,$line,$story, $line->rowid, $object->element);
-		
-		
+
+
 	}
-	
+
 	public static function parseLines(&$object,&$project,&$start,&$end)
 	{
 		global $conf,$langs,$db,$user,$TStory;
-		
+		global $hookmanager;
+
 		if (empty($TStory)) $TStory = array();
-		
+
 		dol_include_once('/subtotal/class/subtotal.class.php');
 		// CREATION D'UNE TACHE GLOBAL POUR LA SAISIE DES TEMPS
 		if (!empty($conf->global->DOC2PROJECT_CREATE_GLOBAL_TASK))
 		{
 			self::createOneTask($project->id, $conf->global->DOC2PROJECT_TASK_REF_PREFIX.'GLOBAL', $langs->trans('Doc2ProjectGlobalTaskLabel'), $langs->trans('Doc2ProjectGlobalTaskDesc'));
 		}
-	
+
 		// Tableau qui va contenir à chaque indice (niveau du titre) l'id de la dernier tache parent
 		// Par contre il faut les titres suivants correctement, T1 => T2 => T3 ... et pas de T1 => T3, dans ce cas T3 sera du même niveau que T1
 		$TTask_id_parent = array();
 		$index = 1;
-//var_dump($object->lines);exit;		
+//var_dump($object->lines);exit;
 		$fk_task_parent = 0;
 		$object->fetch_lines();
 		$story = '';
-		
+
 		// CREATION DES TACHES PAR RAPPORT AUX LIGNES DE LA COMMANDE
 		foreach($object->lines as &$line)
 		{
-			// Excluded product 
+			// Excluded product
 			if(self::isExclude($line)) continue;
-			
+
 			if(!empty($conf->global->DOC2PROJECT_CREATE_SPRINT_FROM_TITLE) && !empty($conf->subtotal->enabled) && ! TSubtotal::isModSubtotalLine($line)){
 				$TTitle = TSubtotal::getAllTitleFromLine($line);
 				if(! empty($TTitle)) {
@@ -322,7 +323,7 @@ class Doc2Project {
 					if (!in_array($story, $TStory)) $TStory[] = $story;
 				}
 			}
-			
+
 			if (!empty($conf->global->DOC2PROJECT_CREATE_TASK_WITH_SUBTOTAL) && $conf->subtotal->enabled && $line->product_type == 9) null; // Si la conf
 			else if ($line->product_type == 9) continue;
 
@@ -332,10 +333,10 @@ class Doc2Project {
 				{
 					$index = $line->qty - 1; // -1 pcq je veux savoir si un id task existe sur un niveau parent
 					$fk_task_parent = isset($TTask_id_parent[$index]) && !empty($TTask_id_parent[$index]) ? $TTask_id_parent[$index] : 0;
-					
+
 					$label = !empty($line->product_label) ? $line->product_label : $line->desc;
 					$fk_task_parent = self::createOneTask($project->id, $conf->global->DOC2PROJECT_TASK_REF_PREFIX.$line->rowid, $label, '', '', '', $fk_task_parent, $line->rowid, $object->element);
-						
+
 					$TTask_id_parent[$index+1] = $fk_task_parent; //+1 pcq je replace le titre à son niveau (exemple : titre niveau 2 à l'indice 2)
 				}
 				else // SOUS-TOTAL
@@ -343,7 +344,7 @@ class Doc2Project {
 					$index = 100 - $line->qty - 1;
 					$fk_task_parent = isset($TTask_id_parent[$index]) && !empty($TTask_id_parent[$index]) ? $TTask_id_parent[$index] : 0;
 				}
-	
+
 			}
 			elseif (!empty($conf->global->DOC2PROJECT_USE_NOMENCLATURE_AND_WORKSTATION))
 			{
@@ -354,7 +355,7 @@ class Doc2Project {
 					dol_include_once('/nomenclature/class/nomenclature.class.php');
 					$nomenclature = new TNomenclature($db);
 					$PDOdb = new TPDOdb($db);
-					
+
 					$nomenclature->loadByObjectId($PDOdb,$line->rowid, $object->element, false, $line->fk_product);//get lines of nomenclature
 					if(!empty($nomenclature->TNomenclatureDet)){
 						$detailsNomenclature=$nomenclature->getDetails($line->qty);
@@ -364,53 +365,53 @@ class Doc2Project {
 					}
 				}
 			}
-				
+
 			// => ligne de type service										=> ligne libre
 			elseif( (!empty($line->fk_product) && $line->fk_product_type == 1) || (!empty($conf->global->DOC2PROJECT_ALLOW_FREE_LINE) && $line->fk_product === null) )
 			{ // On ne créé que les tâches correspondant à des services
-			    
+
 			    $PDOdb = new TPDOdb($db);
 				if(!empty($conf->global->DOC2PROJECT_CREATE_TASK_FOR_VIRTUAL_PRODUCT) && !empty($conf->global->PRODUIT_SOUSPRODUITS) && !is_null($line->ref))
 				{
-					
+
 					$s = new Product($db);
 					$s->fetch($line->fk_product);
 					$s->get_sousproduits_arbo();
 					$TProdArbo = $s->get_arbo_each_prod();
 					$fk_parent = 0;
-					
+
 					if(!empty($TProdArbo)){
-				
+
 						if(!empty($conf->global->DOC2PROJECT_CREATE_TASK_FOR_PARENT)){
 							$fk_parent = self::lineToTask($object, $line,$project,$start,$end,0,true,0,$story);
-							
+
 							if($conf->workstation->enabled && $conf->global->DOC2PROJECT_WITH_WORKSTATION){
 								dol_include_once('/workstation/class/workstation.class.php');
-				
+
 								$Tids = TRequeteCore::get_id_from_what_you_want($PDOdb, MAIN_DB_PREFIX."workstation_product",array('fk_product'=>$line->fk_product));
-				
+
 								foreach ($Tids as $workstationProductid) {
 									$TWorkstationProduct = new TWorkstationProduct;
 									$TWorkstationProduct->load($PDOdb, $workstationProductid);
-				
+
 									$TWorkstation = new TWorkstation;
 									$TWorkstation->load($PDOdb, $TWorkstationProduct->fk_workstation);
-				
+
 									$line->fk_product = $line->fk_product;
 									//$line->qty = $line->qty * $TWorkstationProduct->nb_hour;
 									$line->product_label = $TWorkstation->name;
 									$line->desc = '';
 									$line->total_ht = 0;
-				
+
 									self::lineToTask($object,$line, $project, $start,$end,$fk_parent,false,$TWorkstation->rowid,$story);
 								}
 							}
 						}
-						
+
 						foreach($TProdArbo as $prod){
-				
+
 							if($prod['type'] == 1){ //Uniquement les services
-				
+
 								$ss = new Product($db);
 								$ss->fetch($prod['id']);
 								$line->fk_product = $ss->id;
@@ -419,36 +420,36 @@ class Doc2Project {
 								$line->product_label = $prod['label'];
 								$line->desc = ($ss->description) ? $ss->description : '';
 								$line->total_ht = $ss->price;
-				
+
 								$new_fk_parent = self::lineToTask($object,$line, $project,$start,$end,$fk_parent,false,0,$story);
-								
+
 								if (!empty($conf->global->DOC2PROJECT_TASK_NAME)) $label = strtr($conf->global->DOC2PROJECT_TASK_NAME, array('{product_ref}' => $line->ref, '{product_label}' => $line->product_label));
 								else $label = !empty($line->product_label) ? $line->product_label : $line->desc;
-								
+
 								$defaultref='';
 								if(!empty($conf->global->DOC2PROJECT_TASK_REF_PREFIX)) {
 								    $defaultref = $conf->global->DOC2PROJECT_TASK_REF_PREFIX.$line->rowid.'-'.$ss->id;
 								}
 								$new_fk_parent = self::createOneTask( $project->id, $defaultref, $label, $line->desc, $start, $end, $fk_parent, $qty * $prod['nb'] * 60 * 60, $line->total_ht,0,$line,$story, $line->rowid, $object->element);
-		
+
 								if(!empty($conf->workstation->enabled) && !empty($conf->global->DOC2PROJECT_WITH_WORKSTATION)){
 									dol_include_once('/workstation/class/workstation.class.php');
-				
+
 									$Tids = TRequeteCore::get_id_from_what_you_want($PDOdb, MAIN_DB_PREFIX."workstation_product",array('fk_product'=>$ss->id));
 									if(!empty($Tids)) {
 										foreach ($Tids as $workstationProductid) {
 											$TWorkstationProduct = new TWorkstationProduct;
 											$TWorkstationProduct->load($PDOdb, $workstationProductid);
-					
+
 											$TWorkstation = new TWorkstation;
 											$TWorkstation->load($PDOdb, $TWorkstationProduct->fk_workstation);
-					
+
 											$line->fk_product = $ss->id;
 											$line->qty = $line->qty * $TWorkstationProduct->nb_hour;
 											$line->product_label = $TWorkstation->name;
 											$line->desc = '';
 											$line->total_ht = 0;
-					
+
 											self::lineToTask($object,$line, $project, $start,$end,$new_fk_parent,false,$TWorkstation->rowid,$story);
 										}
 									}
@@ -456,38 +457,40 @@ class Doc2Project {
 							}
 						}
 					}else{
-						
+
 						self::lineToTask($object,$line,$project,$start,$end,0,false,0,$story);
 					}
 				}
 				else{
-					
+
 					self::lineToTask($object,$line,$project,$start,$end,0,false,0,$story);
 				}
 			}
 		}
-		
+
 		if($conf->global->DOC2PROJECT_CREATE_SPRINT_FROM_TITLE && $conf->subtotal->enabled)
 		{
 			$project->statut=0;
 			$project->array_options['options_stories'] = implode(',', $TStory);
 			$project->update($user);
 		}
+		$parameters = array('project' => $project);
+		$reshook = $hookmanager->executeHooks('tasksCreated', $parameters, $object, $action);
 	}
-	
+
 
 	public static function createOneTask($fk_project, $ref, $label='', $desc='', $start='', $end='', $fk_task_parent=0, $planned_workload='', $total_ht='', $fk_workstation = 0,$line='',$story='', $fk_origin='', $origin_type='')
 	{
 		global $conf,$langs,$db,$user,$hookmanager;
-		
+
 		$hookmanager->initHooks(array('doc2projecttaskcard'));
-		
+
 		$task = new Task($db);
-		
+
 		$action = 'createOneTask';
 		$parameters = array('db' => &$db, 'fk_project' => $fk_project, 'ref' => $ref, 'label' => $label, 'desc' => $desc, 'start' => $start, 'end' => $end, 'fk_task_parent' => $fk_task_parent, 'planned_workload' => $planned_workload, 'total_ht' => $total_ht, 'fk_workstation' => $fk_workstation, 'line' => $line);
-		$reshook = $hookmanager->executeHooks('createTask', $parameters, $task, $action);	
-		
+		$reshook = $hookmanager->executeHooks('createTask', $parameters, $task, $action);
+
 		if (!empty($hookmanager->resArray))
 		{
 			return $hookmanager->resArray[0]->id;
@@ -495,9 +498,9 @@ class Doc2Project {
 		else
 		{
 			$task->fetch('',$ref);
-			
+
 			$story_k = self::getStoryK($story);
-			
+
 			if (!empty($line))
 			{
 				if (empty($line->array_options) && method_exists($line, 'fetch_optionals')) $line->fetch_optionals($line->id?$line->id:$line->rowid);
@@ -511,7 +514,7 @@ class Doc2Project {
 					if (!empty($line->array_options['options_'.$key])) $task->array_options['options_'.$key] = $line->array_options['options_'.$key];
 				}
 			}
-			
+
 			if($task->id>0) {
 				$task->planned_workload = $planned_workload;
 				$task->fk_project = $fk_project;
@@ -519,7 +522,7 @@ class Doc2Project {
 				if($fk_workstation) $task->array_options['options_fk_workstation'] = $fk_workstation;
 				$task->array_options['options_soldprice'] = $total_ht;
 				$task->progress = (int)$task->progress;
-				
+
 				$action = 'updateOneTask';
 				$parameters = array('db' => &$db, 'fk_project' => $fk_project, 'ref' => $ref, 'label' => $label, 'desc' => $desc, 'start' => $start, 'end' => $end, 'fk_task_parent' => $fk_task_parent, 'planned_workload' => $planned_workload, 'total_ht' => $total_ht, 'fk_workstation' => $fk_workstation, 'line' => $line);
 				$reshook = $hookmanager->executeHooks('addMoreParams', $parameters, $task, $action);
@@ -527,12 +530,12 @@ class Doc2Project {
 				if($conf->global->DOC2PROJECT_CREATE_SPRINT_FROM_TITLE && !is_null($story_k)){
 					Doc2Project::setStoryK($db, $task->id, $story_k);
 				}
-				
+
 				if(! empty($fk_origin)) {
 					if($origin_type == 'propal') $task->add_object_linked('propaldet', $fk_origin);
 					elseif($origin_type == 'commande') $task->add_object_linked('orderline', $fk_origin);
 				}
-				
+
 				return $task->id;
 			}
 			else{
@@ -550,13 +553,13 @@ class Doc2Project {
 
 				if($fk_workstation) $task->array_options['options_fk_workstation'] = $fk_workstation;
 				$task->array_options['options_soldprice'] = $total_ht;
-				
+
 				$action = 'createOneTask';
 				$parameters = array('db' => &$db, 'fk_project' => $fk_project, 'ref' => $ref, 'label' => $label, 'desc' => $desc, 'start' => $start, 'end' => $end, 'fk_task_parent' => $fk_task_parent, 'planned_workload' => $planned_workload, 'total_ht' => $total_ht, 'fk_workstation' => $fk_workstation, 'line' => $line);
 				$reshook = $hookmanager->executeHooks('addMoreParams', $parameters, $task, $action);
 
 				$r = $task->create($user);
-				
+
 				if ($r > 0) {
 					if($conf->global->DOC2PROJECT_CREATE_SPRINT_FROM_TITLE && !is_null($story_k)){
 						Doc2Project::setStoryK($db, $r, $story_k);
@@ -565,18 +568,18 @@ class Doc2Project {
 						if($origin_type == 'propal') $task->add_object_linked('propaldet', $fk_origin);
 						elseif($origin_type == 'commande') $task->add_object_linked('orderline', $fk_origin);
 					}
-					
+
 					return $r;
 				} else {
 					dol_print_error($db);
 				}
 
-			}	
+			}
 		}
-		
+
 		return 0;
 	}
-	
+
 //Sprint scrumboard
 	public static function setStoryK($db,$id, $nbstory)
 	{
@@ -585,24 +588,24 @@ class Doc2Project {
 		if($resql) return 1;
 		return 0;
 	}
-	
+
 	public static function getStoryK($story) {
 		global $conf, $TStory;
 //		var_dump($TStory, $story);
 		if($conf->global->DOC2PROJECT_CREATE_SPRINT_FROM_TITLE && !empty($story)) {
 			$key = array_search($story, $TStory);
 //			var_dump($key, '-------------------------------------');
-			if ($key !== false) return $key+1; // décalage suite 
+			if ($key !== false) return $key+1; // décalage suite
 		}
-		
+
 		return null;
 	}
-	
+
 	/* Converti une ligne de nomenclature en tache.
-	 * $detailsNomenclature => resultat de getDetails() de la classe nomenclature 
+	 * $detailsNomenclature => resultat de getDetails() de la classe nomenclature
 	 * $line => ligne courante (propaldet/orderdet)
 	 * $object => objet courant (propal/order)
-	 * 
+	 *
 	 */
 	public static function nomenclatureToTask($detailsNomenclature,$line,$object, $project, $start, $end,$stories='')
 	{
@@ -615,20 +618,20 @@ class Doc2Project {
 			{
 				$lineNomenclature->$key = $value;
 			}
-			
+
 			$product = new Product($db);
 			$product->fetch($lineNomenclature->fk_product);
 			//On prend les services les plus bas pour créer les taches
-			
+
 			if (( $product->type == 1) && (TNomenclature::noProductOfThisType($lineNomen['childs'],1) || empty($lineNomenclature->childs)))
 			{
 				//Le calcul des quantités est déjà fait grâce à getDetails
 				$lineNomenclature->product_label = $line->product_label.' - '.$product->label; //To difference tasks label
-				
+
 				$lineNomenclature->desc = $product->description;
 				$nomenclature = new TNomenclature($db);
 				$PDOdb = new TPDOdb($db);
-				
+
 				$nomenclature->loadByObjectId($PDOdb, $lineNomenclature->rowid,$object->element, false, $lineNomenclature->fk_product);
 				if (!empty($nomenclature->TNomenclatureWorkstation[0]->rowid))
 				{
@@ -638,10 +641,10 @@ class Doc2Project {
 				{
 					$idWorkstation = 0;
 				}
-				
+
 				$lineNomenclature->rowid = $lineNomenclature->rowid.'-'.$lineNomenclature->fk_product.'-'.$line->rowid; //To difference tasks ref
 				self::lineToTask($object, $lineNomenclature, $project, $start, $end, 0, false, $idWorkstation, $stories);
-				
+
 			} elseif(!empty($lineNomenclature->childs)){
 				self::nomenclatureToTask($lineNomenclature->childs, $line,$object, $project, $start, $end,$stories);
 			}


### PR DESCRIPTION
# NEW
Ajout d’un hook permettant au clieprolor de créer une tâche une fois que toutes les autres tâches doc2projet ont été créées.

Ce hook pourrait éventuellement être utile dans la branche actuelle de doc2project (pour d’autres clients), mais doc2project n’utilise pas encore la nouvelle méthode pour les branches et je ne sais même pas de quelle branche partir.
