### PR TITLE
Fix create project from propal

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 ## 3.1
+- FIX: lors de la génération d'un projet (déjà existant) depuis une propal un warning   - *04/02/2022* - 3.1.3
+    s'affichait sur l'affectation de valeur sur un extrafield
 - FIX: Création des postes de travail n'étaient pas fonctionnel en fonction des sous produits - *14/12/2021* - 3.1.1
 - NEW: Nouvelle conf permettant d'avoir en permanence le nom de la société dans le titre du projet - *17/11/2021* - 3.1.0
 

--- a/class/doc2project.class.php
+++ b/class/doc2project.class.php
@@ -759,7 +759,7 @@ class Doc2Project {
 
 			        //var_dump(array($task->planned_workload / 3600 , $planned_workload / 3600, ($task->planned_workload + $planned_workload) / 3600));
 			        $task->planned_workload = $task->planned_workload + $planned_workload;
-			        $task->array_options['options_soldprice'] = $task->array_options['options_soldprice'] + $total_ht;
+			        $task->array_options['options_soldprice'] = floatval($task->array_options['options_soldprice']) + floatval($total_ht);
 
 			        // new planification calculation
 			        self::includeNewStartEndDateToTask($task,$start, $end);

--- a/core/modules/modDoc2Project.class.php
+++ b/core/modules/modDoc2Project.class.php
@@ -58,7 +58,7 @@ class modDoc2Project extends DolibarrModules
 		// Module description, used if translation string 'ModuleXXXDesc' not found (where XXX is value of numeric property 'numero' of module)
 		$this->description = "Convert a proposal or customer order to a project";
 		// Possible values for version are: 'development', 'experimental', 'dolibarr' or version
-		$this->version = '3.1.1';
+		$this->version = '3.1.3';
 		// Key used in llx_const table to save module status enabled/disabled (where MYMODULE is value of property name of module in uppercase)
 		$this->const_name = 'MAIN_MODULE_'.strtoupper($this->name);
 		// Where to store the module in setup page (0=common,1=interface,2=others,3=very specific)


### PR DESCRIPTION
lors de la génération d'un projet (déjà existant) depuis une propal un warning   - *04/02/2022* - 3.1.3    s'affichait sur l'affectation de valeur sur un extrafield