### PR TITLE
2022.5.3 rc fix colomn offset

### DIFF
--- a/class/actions_doc2project.class.php
+++ b/class/actions_doc2project.class.php
@@ -47,7 +47,7 @@ class ActionsDoc2Project
 								if($( this ).hasClass( "liste_titre" ))
 								{
 									// PARTIE TITRE
-									$('<td class="linecoltasks" style="width: 100px"><?php print $langs->transnoentities('LinkedTasks'); ?></td>').insertBefore($( this ).find("td.linecoldescription"));
+									$('<td class="linecoltasks" style="width: 100px"><?php print $langs->transnoentities('LinkedTasks'); ?></td>').insertBefore($( this ).find("th.linecoldescription,td.linecoldescription"));
 								}
 								else if($( this ).data( "product_type" ) == "9"){
 									$( this ).find("td[colspan]:first").attr('colspan',    parseInt($( this ).find("td[colspan]:first").attr('colspan')) + 1  );


### PR DESCRIPTION
FIX column offset

On order cards, the columns have an offset because the heading for tasks column is not displayed. 

Example here : VAT is label for description and PUHT is 20%.

![image](https://user-images.githubusercontent.com/89838020/224073266-a0a380bd-0174-4637-941f-00cf4cedc265.png)

This is due to heading cells being 'th' and not 'td'.
This commit fixes this behavior.