### PR TITLE
3.4 fix da024918

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 ## 3.4
+- FIX : DA024918 - les lignes libres de service n'étaient plus reprises lors de la création d'un projet et de ses tâches depuis une proposition commerciale - *30/04/2024* - 3.4.3  
 - FIX : $this->db remove and msg  added on conf description   - *27/02/2024* - 3.4.2  
 - FIX : Fatal this->db was always empty - *22/01/2024* - 3.4.1
 - NEW :   Changed Dolibarr compatibility range to 12 min - 19 max  	- *29/11/2023* - 3.4.0

--- a/class/actions_doc2project.class.php
+++ b/class/actions_doc2project.class.php
@@ -306,7 +306,7 @@ class ActionsDoc2Project extends doc2project\RetroCompatCommonHookActions
 				$end = '';
 
 				$TlinesInfos = Doc2Project::parseLines($object, $project, $start,$end);
-                // un peu d'info c'est mieux que rien. Pour les détails par contre on peut se gratter
+
                 if(!empty(getDolGlobalInt('DOC2PROJECT_DEBUGCREATETASK'))) {
                     $TmsgsDef = array(
                         'linesActuallyAdded' => 'mesgs', // plus fiable que linesImported

--- a/class/doc2project.class.php
+++ b/class/doc2project.class.php
@@ -28,8 +28,10 @@ class Doc2Project {
 		if (getDolGlobalInt('DOC2PROJECT_DO_NOT_CONVERT_SERVICE_WITH_QUANTITY_ZERO') && $line->qty == 0) return   true;
 
 		// FROM CONFIG : PRODUCT REF
-		$TExclude = explode(';', getDolGlobalString('DOC2PROJECT_EXCLUDED_PRODUCTS'));
-		if (count($TExclude) > 0 && in_array($line->ref, $TExclude)) return  true;
+		if(!empty(getDolGlobalString('DOC2PROJECT_EXCLUDED_PRODUCTS'))) {
+			$TExclude = explode(';', getDolGlobalString('DOC2PROJECT_EXCLUDED_PRODUCTS'));
+			if (count($TExclude) > 0 && in_array($line->ref, $TExclude)) return  true;
+		}
 
 		// Subtotal
 		if (!getDolGlobalInt('DOC2PROJECT_CREATE_TASK_WITH_SUBTOTAL') && !empty($conf->subtotal->enabled) && TSubtotal::isModSubtotalLine($line)) return true;
@@ -289,9 +291,20 @@ class Doc2Project {
 
 
 
-    // return array 'linesImported' => int, 'linesExcluded' => int, 'linesImportError' => int
-    // parce que c'est mieux que ce qu'il y avait avant ie fck all
-	public static function parseLines(&$object,&$project,&$start,&$end, &$story = '') : array
+    // return array
+
+	/**
+	 *
+	 * Création des tâches liées au projet renseigné en paramètre depuis l'objet lui même renseigné en paramètre
+	 *
+	 * @param $object
+	 * @param $project
+	 * @param $start
+	 * @param $end
+	 * @param $story
+	 * @return int[]
+	 */
+	public static function parseLines(&$object, &$project, &$start, &$end, &$story = '') : array
 	{
 		global $conf,$langs,$db,$user,$TStory;
 
@@ -310,14 +323,13 @@ class Doc2Project {
 		// Par contre il faut les titres suivants correctement, T1 => T2 => T3 ... et pas de T1 => T3, dans ce cas T3 sera du même niveau que T1
 		$TTask_id_parent = array();
 		$index = 1;
-        //var_dump($object->lines);exit;
 		$fk_task_parent = 0;
 
 		$linesImported = 0;
 		$linesExcluded = 0;
 		$linesImportError = 0;
 
-        $TremonterDesInfosCestBien = array ('linesImported' => &$linesImported, 'linesExcluded' => &$linesExcluded, 'linesImportError' => &$linesImportError);
+        $TInfos = array ('linesImported' => &$linesImported, 'linesExcluded' => &$linesExcluded, 'linesImportError' => &$linesImportError);
 
 		$TTaskAddedList = array(); // populate with task id
 
@@ -331,13 +343,10 @@ class Doc2Project {
 			}
 
 			// EXCLUDED LINES
-            // on test maintenant puis plus bas on reteste pour refaire rien :/
 			if(self::isExclude($line)){
-			    $linesExcluded ++;
+				$linesExcluded ++;
 			    continue;
 			}
-
-			// $linesImported++; un peu useless de faire ça _AVANT_ d'importer
 
 			if (!empty($conf->subtotal->enabled) && TSubtotal::isModSubtotalLine($line))
 			{
@@ -561,8 +570,8 @@ class Doc2Project {
 			self::resetDateTaskForProjectFromTaskList($project, getDolGlobalInt('DOC2PROJECT_NB_HOURS_PER_DAY') * 3600, $TTaskAddedList);
 		}
 
-        $TremonterDesInfosCestBien['linesActuallyAdded'] = count($TTaskAddedList);
-        return $TremonterDesInfosCestBien;
+		$TInfos['linesActuallyAdded'] = count($TTaskAddedList);
+        return $TInfos;
 	}
 
 	/**

--- a/class/doc2project.class.php
+++ b/class/doc2project.class.php
@@ -293,11 +293,11 @@ class Doc2Project {
 	 *
 	 * Création des tâches liées au projet renseigné en paramètre depuis l'objet lui même renseigné en paramètre
 	 *
-	 * @param $object
-	 * @param $project
-	 * @param $start
-	 * @param $end
-	 * @param $story
+	 * @param CommonObject $object
+	 * @param Project $project
+	 * @param int $start
+	 * @param int $end
+	 * @param string $story
 	 * @return array
 	 */
 	public static function parseLines(&$object, &$project, &$start, &$end, &$story = '') : array

--- a/class/doc2project.class.php
+++ b/class/doc2project.class.php
@@ -289,10 +289,6 @@ class Doc2Project {
 
 	}
 
-
-
-    // return array
-
 	/**
 	 *
 	 * Création des tâches liées au projet renseigné en paramètre depuis l'objet lui même renseigné en paramètre
@@ -302,7 +298,7 @@ class Doc2Project {
 	 * @param $start
 	 * @param $end
 	 * @param $story
-	 * @return int[]
+	 * @return array
 	 */
 	public static function parseLines(&$object, &$project, &$start, &$end, &$story = '') : array
 	{

--- a/core/modules/modDoc2Project.class.php
+++ b/core/modules/modDoc2Project.class.php
@@ -58,7 +58,7 @@ class modDoc2Project extends DolibarrModules
 		// Module description, used if translation string 'ModuleXXXDesc' not found (where XXX is value of numeric property 'numero' of module)
 		$this->description = "Convert a proposal or customer order to a project";
 		// Possible values for version are: 'development', 'experimental', 'dolibarr' or version
-		$this->version = '3.4.2';
+		$this->version = '3.4.3';
 		// Url to the file with your last numberversion of this module
 		require_once __DIR__ . '/../../class/techatm.class.php';
 		$this->url_last_version = \doc2project\TechATM::getLastModuleVersionUrl($this);


### PR DESCRIPTION
- FIX : DA024918 - les lignes libres de service n'étaient plus reprises lors de la création d'un projet et de ses tâches depuis une proposition commerciale
Bug créé lors de la mise en compat'

- Clean des commentaires / noms de variable peu appropriés dans un code de module vendu