### PR TITLE
FIX : remove useless function, usage_task is standard behaviour

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 
 ## 3.5
+- FIX : remove useless function, usage_task is standard behaviour - *07/08/2024* - 3.5.2
 - FIX : remove useless code for < 3.6 version - *07/08/2024* - 3.5.1
 - NEW : Compatibility V20, changed Dolibarr compatibility 16 min - 20 max - *03/07/2024* - 3.5.0
 

--- a/admin/doc2project_setup.php
+++ b/admin/doc2project_setup.php
@@ -154,10 +154,6 @@ if($ok) {
 	// Cloner les attributs suppémentaires du document source sur le projet
 	_print_on_off('DOC2PROJECT_CLONE_EXTRAFIELDS', $langs->trans('Doc2ProjectCloneExtrafields'));
 
-	// Cocher la case pour suivre les tâches et le temps passé à la création auto d'un projet
-	_print_on_off('DOC2PROJECT_ADD_USAGE_TASK_ON_PROJECT', $langs->trans('Doc2ProjectAddUsageTaskOnProject'));
-
-
 	/**
 	 * TASK PARAMETERS
 	 */

--- a/class/actions_doc2project.class.php
+++ b/class/actions_doc2project.class.php
@@ -294,35 +294,4 @@ class ActionsDoc2Project extends doc2project\RetroCompatCommonHookActions
 
 		return 0;
 	}
-
-	/**
-	 * afterCreateProject
-	 *
-	 * @param array()		$parameters		Hook metadatas (context, etc...)
-	 * @param CommonObject	&$object		The object being processed (e.g., an invoice, proposal, etc...)
-	 * @param string		&$action		The current action (usually create, edit, or null)
-	 * @param HookManager	$hookmanager	Hook manager instance to allow calling another hook
-	 * @return int			Returns < 0 on error, 0 on success, 1 to replace standard code
-	 */
-	function afterCreateProject($parameters, &$object, &$action, $hookmanager): int
-	{
-		global $conf, $user, $db;
-		if ($action == 'afterCreateProject' && !empty($conf->global->DOC2PROJECT_ADD_USAGE_TASK_ON_PROJECT)){
-			$project = new Project($db);
-			if ($project->fetch($parameters['project']->id) > 0){
-				$project->usage_task = 1;
-				if ($project->update($user, 1) >= 0) {
-					return 0;
-				}
-				else {
-					setEventMessage($db->lasterror());
-					return -1;
-				}
-			}else {
-				setEventMessage($db->lasterror());
-				return -1;
-			}
-		}
-		return 0;
-	}
 }

--- a/class/doc2project.class.php
+++ b/class/doc2project.class.php
@@ -144,15 +144,15 @@ class Doc2Project {
 				$title = $langs->trans('Doc2ProjectTitle', $title);
 			}
 
-			$project->title			 = $title;
-			$project->socid          = $object->socid;
-			$project->description    = '';
-			$project->public         = 1; // 0 = Contacts du projet  ||  1 = Tout le monde
-			$project->datec			 = dol_now();
-			$project->date_start	 = !empty($object->delivery_date) ? $object->delivery_date : dol_now();
-			$project->date_end		 = null;
+			$project->title			= $title;
+			$project->socid			= $object->socid;
+			$project->description	= '';
+			$project->public		= 1; // 0 = Contacts du projet  ||  1 = Tout le monde
+			$project->usage_task	= 1;
+			$project->date_start	= !empty($object->delivery_date) ? $object->delivery_date : dol_now();
+			$project->date_end		= null;
 
-			$project->ref 			 = self::get_project_ref($project);
+			$project->ref			= self::get_project_ref($project);
 
 			$r = $project->create($user);
 			if ($r > 0)

--- a/core/modules/modDoc2Project.class.php
+++ b/core/modules/modDoc2Project.class.php
@@ -58,7 +58,7 @@ class modDoc2Project extends DolibarrModules
 		// Module description, used if translation string 'ModuleXXXDesc' not found (where XXX is value of numeric property 'numero' of module)
 		$this->description = "Convert a proposal or customer order to a project";
 		// Possible values for version are: 'development', 'experimental', 'dolibarr' or version
-		$this->version = '3.5.0';
+		$this->version = '3.5.2';
 		// Url to the file with your last numberversion of this module
 		require_once __DIR__ . '/../../class/techatm.class.php';
 		$this->url_last_version = \doc2project\TechATM::getLastModuleVersionUrl($this);
@@ -122,9 +122,7 @@ class modDoc2Project extends DolibarrModules
 			array('DOC2PROJECT_AUTO_ON_PROPOSAL_CLOSE','chaine','0','Launch function when proposal is closed signed',1),
 			array('DOC2PROJECT_AUTO_ON_ORDER_VALIDATE','chaine','0','Launch function when order is validated',1),
 			array('DOC2PROJECT_NB_HOURS_PER_DAY','chaine','7','Used to convert service duration in hours',1),
-			array('DOC2PROJECT_TASK_REF_PREFIX','chaine','TA','Prefix for task reference, will be used with proposal or order line ID to be unique',1),
-			array('DOC2PROJECT_ADD_USAGE_TASK_ON_PROJECT','chaine','0','Check the box to track tasks and time spent on automatic project creation',1)
-
+			array('DOC2PROJECT_TASK_REF_PREFIX','chaine','TA','Prefix for task reference, will be used with proposal or order line ID to be unique',1)
 		);
 
 		// Array to add new pages in new tabs


### PR DESCRIPTION
Doc2project is made to convert a doc to a project with task. The option "usage_task" on project must be selected as this is basic behaviour of the module.
Furthermore, using a hook inside the module declaring the hook is overkill :)